### PR TITLE
Add contains command

### DIFF
--- a/cmd/contains.go
+++ b/cmd/contains.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/code-ready/admin-helper/pkg/hosts"
+	"github.com/spf13/cobra"
+)
+
+var Contains = &cobra.Command{
+	Use:   "contains",
+	Short: "Check if an ip and host are present in hosts file",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return contains(args)
+	},
+}
+
+func contains(args []string) error {
+	hosts, err := hosts.New()
+	if err != nil {
+		return err
+	}
+	if hosts.Contains(args[0], args[1]) {
+		fmt.Println("true")
+	} else {
+		fmt.Println("false")
+	}
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,5 +9,6 @@ func Commands() []*cobra.Command {
 		Add,
 		Remove,
 		Clean,
+		Contains,
 	}
 }

--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -91,3 +91,7 @@ func (h *Hosts) Clean(rawSuffixes []string) error {
 	}
 	return h.File.Flush()
 }
+
+func (h *Hosts) Contains(ip, host string) bool {
+	return h.File.Has(ip, host)
+}

--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -17,15 +17,16 @@ func New() (*Hosts, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !file.IsWritable() {
-		return nil, fmt.Errorf("host file not writable, try running with elevated privileges")
-	}
 	return &Hosts{
 		File: &file,
 	}, nil
 }
 
 func (h *Hosts) Add(ip string, hosts []string) error {
+	if err := h.checkIsWritable(); err != nil {
+		return err
+	}
+
 	uniqueHosts := map[string]bool{}
 	for i := 0; i < len(hosts); i++ {
 		uniqueHosts[hosts[i]] = true
@@ -45,6 +46,10 @@ func (h *Hosts) Add(ip string, hosts []string) error {
 }
 
 func (h *Hosts) Remove(hosts []string) error {
+	if err := h.checkIsWritable(); err != nil {
+		return err
+	}
+
 	uniqueHosts := map[string]bool{}
 	for i := 0; i < len(hosts); i++ {
 		uniqueHosts[hosts[i]] = true
@@ -64,6 +69,10 @@ func (h *Hosts) Remove(hosts []string) error {
 }
 
 func (h *Hosts) Clean(rawSuffixes []string) error {
+	if err := h.checkIsWritable(); err != nil {
+		return err
+	}
+
 	var suffixes []string
 	for _, suffix := range rawSuffixes {
 		if !strings.HasPrefix(suffix, ".") {
@@ -90,6 +99,13 @@ func (h *Hosts) Clean(rawSuffixes []string) error {
 		}
 	}
 	return h.File.Flush()
+}
+
+func (h *Hosts) checkIsWritable() error {
+	if !h.File.IsWritable() {
+		return fmt.Errorf("host file not writable, try running with elevated privileges")
+	}
+	return nil
 }
 
 func (h *Hosts) Contains(ip, host string) bool {

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -63,6 +63,21 @@ func TestClean(t *testing.T) {
 	assert.Equal(t, "127.0.0.1 entry2.suffix2"+eol(), string(content))
 }
 
+func TestContains(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hosts")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	hostsFile := filepath.Join(dir, "hosts")
+	assert.NoError(t, ioutil.WriteFile(hostsFile, []byte(`127.0.0.1 entry1.suffix1 entry2.suffix2`), 0600))
+
+	host := hosts(t, hostsFile)
+
+	assert.True(t, host.Contains("127.0.0.1", "entry1.suffix1"))
+	assert.False(t, host.Contains("127.0.0.2", "entry1.suffix1"))
+	assert.False(t, host.Contains("127.0.0.1", "entry1.suffix2"))
+}
+
 func hosts(t *testing.T, hostsFile string) Hosts {
 	file, err := hostsfile.NewCustomHosts(hostsFile)
 	assert.NoError(t, err)


### PR DESCRIPTION
It is useful to be able to check if an hosts file entry is present without having to be root.

It can be called as user before an eventual add or remove command.