### PR TITLE
spec: Autogenerate Requires: bundled()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ admin-helper.exe
 dist
 out
 release
+crc-admin-helper.spec

--- a/crc-admin-helper.spec.in
+++ b/crc-admin-helper.spec.in
@@ -31,14 +31,7 @@ BuildRequires: git-core
 BuildRequires: go-srpm-macros
 BuildRequires: make
 
-Provides: bundled(golang(github.com/davecgh/go-spew)) = 1.1.1
-Provides: bundled(golang(github.com/dimchansky/utfbom)) = 1.1.1
-Provides: bundled(golang(github.com/goodhosts/hostsfile)) = 0.0.7
-Provides: bundled(golang(github.com/inconshreveable/mousetrap)) = 1.0.0
-Provides: bundled(golang(github.com/pmezard/go-difflib)) = 1.0.0
-Provides: bundled(golang(github.com/spf13/cobra)) = 1.1.1
-Provides: bundled(golang(github.com/spf13/pflag)) = 1.0.5
-Provides: bundled(golang(github.com/stretchr/testify)) = 1.3.0
+__BUNDLED_REQUIRES__
 
 %description
 %{common_description}


### PR DESCRIPTION
This makes use of https://github.com/cfergeau/gomod2rpmdeps/ in order
to add virtual requires for the go modules which are vendored by
admin-helper.