### PR TITLE
Verify hosts to delete instead of suffixes when cleaning hosts file

### DIFF
--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -97,10 +97,6 @@ func (h *Hosts) Remove(hosts []string) error {
 }
 
 func (h *Hosts) Clean(rawSuffixes []string) error {
-	if err := h.verifyHosts(rawSuffixes); err != nil {
-		return err
-	}
-
 	if err := h.checkIsWritable(); err != nil {
 		return err
 	}
@@ -123,6 +119,10 @@ func (h *Hosts) Clean(rawSuffixes []string) error {
 				}
 			}
 		}
+	}
+
+	if err := h.verifyHosts(toDelete); err != nil {
+		return err
 	}
 
 	for _, host := range toDelete {

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -84,7 +84,7 @@ func TestSuffixFilter(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	hostsFile := filepath.Join(dir, "hosts")
-	assert.NoError(t, ioutil.WriteFile(hostsFile, []byte(`127.0.0.1 localhost`), 0600))
+	assert.NoError(t, ioutil.WriteFile(hostsFile, []byte(`127.0.0.1 localhost localhost.localdomain`), 0600))
 
 	file, err := hostsfile.NewCustomHosts(hostsFile)
 	assert.NoError(t, err)
@@ -99,6 +99,8 @@ func TestSuffixFilter(t *testing.T) {
 	assert.Error(t, host.Add("127.0.0.1", []string{"host.poison"}))
 	assert.Error(t, host.Add("127.0.0.1", []string{"CAPITAL.crc.testing"}))
 	assert.Error(t, host.Remove([]string{"localhost"}))
+	assert.NoError(t, host.Clean([]string{".crc.testing"}))
+	assert.Error(t, host.Clean([]string{".localdomain"}))
 }
 
 func hosts(t *testing.T, hostsFile string) Hosts {


### PR DESCRIPTION
Attackers can pass a bad domain suffix, it will be rejected before writing hosts file.
It avoids writing a second filter function.