### PR TITLE
daemon: Re-read hosts file for each request

### DIFF
--- a/cmd/admin-helper/daemon.go
+++ b/cmd/admin-helper/daemon.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/code-ready/admin-helper/pkg/api"
-	"github.com/code-ready/admin-helper/pkg/hosts"
 	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
 )
@@ -80,12 +79,7 @@ func (p *program) Start(s service.Service) error {
 			_ = logger.Error(err)
 			return
 		}
-		hosts, err := hosts.New()
-		if err != nil {
-			_ = logger.Error(err)
-			return
-		}
-		if err := http.Serve(ln, api.Mux(hosts)); err != nil {
+		if err := http.Serve(ln, api.Mux()); err != nil {
 			_ = logger.Error(err)
 			return
 		}

--- a/pkg/api/mux.go
+++ b/pkg/api/mux.go
@@ -10,7 +10,7 @@ import (
 	"github.com/code-ready/admin-helper/pkg/types"
 )
 
-func Mux(hosts *hosts.Hosts) http.Handler {
+func Mux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, constants.Version)

--- a/pkg/api/mux_test.go
+++ b/pkg/api/mux_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMux(t *testing.T) {
-	ts := httptest.NewServer(Mux(nil))
+	ts := httptest.NewServer(Mux())
 	defer ts.Close()
 
 	client := client.New(http.DefaultClient, ts.URL)

--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -43,6 +43,14 @@ func defaultFilter(s string) bool {
 	return clusterRegexp.MatchString(s) || appRegexp.MatchString(s)
 }
 
+func Add(ip string, hosts []string) error {
+	h, err := New()
+	if err != nil {
+		return err
+	}
+	return h.Add(ip, hosts)
+}
+
 func (h *Hosts) Add(ip string, hosts []string) error {
 	if err := h.verifyHosts(hosts); err != nil {
 		return err
@@ -75,6 +83,14 @@ func (h *Hosts) Add(ip string, hosts []string) error {
 	return h.File.Flush()
 }
 
+func Remove(hosts []string) error {
+	h, err := New()
+	if err != nil {
+		return err
+	}
+	return h.Remove(hosts)
+}
+
 func (h *Hosts) Remove(hosts []string) error {
 	if err := h.verifyHosts(hosts); err != nil {
 		return err
@@ -100,6 +116,14 @@ func (h *Hosts) Remove(hosts []string) error {
 		}
 	}
 	return h.File.Flush()
+}
+
+func Clean(rawSuffixes []string) error {
+	h, err := New()
+	if err != nil {
+		return err
+	}
+	return h.Clean(rawSuffixes)
 }
 
 func (h *Hosts) Clean(rawSuffixes []string) error {


### PR DESCRIPTION
This is quite wasteful, but after hostsfile.Clean() has been called,
the parsed hostfile is no longer valid, and adding more data to it
causes some of its content to disappear, see
https://github.com/code-ready/admin-helper/pull/23#issuecomment-971141415

This issue can only be seen when the admin-helper daemon is used, and
when there's a limit to the number of entries per line, which means this
can only be reproduced on Windows.

By reparsing the hostfile each time we get a request, we workaround this
bug.