### PR TITLE
correct name of arm64 target in make cross receipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe:
 	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe $(GO_BUILDFLAGS) ./cmd/admin-helper/
 
 .PHONY: cross ## Cross compiles all binaries
-cross: $(BUILD_DIR)/macos-amd64/$(BINARY_NAME) $(BUILD_DIR)/macos-arm64/$(BINARY_NAME) $(BUILD_DIR)/linux-amd64/$(BINARY_NAME) $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe
+cross: $(BUILD_DIR)/macos-amd64/$(BINARY_NAME) $(BUILD_DIR)/macos-arm64/$(BINARY_NAME)-arm64 $(BUILD_DIR)/linux-amd64/$(BINARY_NAME) $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe
 
 .PHONY: release
 release: clean lint test cross


### PR DESCRIPTION
this was missed in 84463da5ac7ab7e8c090d56abd1cf35eecf5d385 and
results in the following error on `make cross`

```
make: *** No rule to make target 'out/macos-arm64/crc-admin-helper', needed by 'cross'.  Stop.
```