### PR TITLE
build: Trim 'v' prefix from VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Go and compilation related variables
-VERSION ?= $(shell git describe --tags --dirty)
+VERSION ?= $(shell git describe --tags --dirty | tr -d v)
 BUILD_DIR ?= out
 
 GOPATH ?= $(shell go env GOPATH)


### PR DESCRIPTION
When building from git, admin-helper version is inferred from the latest
git tag. If we use the recommended github tag format (v0.0.1), this
means the version will have an unexpected 'v' prefix. This commit
trims it from the version string.